### PR TITLE
Fixing formfield options not showing

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -17,7 +17,7 @@ if (!function_exists('theme_field')){
 		$row->required = $required;
 		$row->field = $key;
 		$row->type = $type;
-		$row->details = $details;
+		$row->details = json_decode($details);
 		$row->display_name = $placeholder;
 
 		$dataTypeContent = new class{ public function getKey(){} };


### PR DESCRIPTION
Hi, Trying to add any formfields with details would result in null options, This will json decode the passed string and fix theme options not showing.