### PR TITLE
Fix error during artisan package:discover

### DIFF
--- a/src/ThemesServiceProvider.php
+++ b/src/ThemesServiceProvider.php
@@ -3,6 +3,7 @@
 namespace DevDojo\Themes;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use TCG\Voyager\Models\Menu;
 use TCG\Voyager\Models\Role;
 use TCG\Voyager\Models\MenuItem;
@@ -29,7 +30,13 @@ class ThemesServiceProvider extends ServiceProvider
     public function register()
     {
         if ( request()->is(config('voyager.prefix')) || request()->is(config('voyager.prefix').'/*') || app()->runningInConsole() ) {
-            $this->addThemesTable();
+
+            try {
+                DB::connection()->getPdo();
+                $this->addThemesTable();
+            } catch (\Exception $e) {
+                \Log::error("Error connecting to database: ".$e->getMessage());
+            }
 
             app(Dispatcher::class)->listen('voyager.menu.display', function ($menu) {
                 $this->addThemeMenuItem($menu);


### PR DESCRIPTION
Fix an issue during Wave deployment to the DigitalOcean App Platform:
<img width="875" alt="image" src="https://user-images.githubusercontent.com/21223421/198230670-a421a0dd-bf9e-459e-b94d-0d48d13de7c8.png">

During the build process the database details are not available, so we need to make sure that we can run `composer install` without making any calls to the DB.