### PR TITLE
Fix: Deprecated Dynamic Property Creation in PHP 8.3

### DIFF
--- a/src/ThemesServiceProvider.php
+++ b/src/ThemesServiceProvider.php
@@ -22,6 +22,8 @@ class ThemesServiceProvider extends ServiceProvider
             'ThemeOptions',
         ];
 
+    private $themes_folder;
+
     /**
      * Register is loaded every time the voyager themes hook is used.
      *


### PR DESCRIPTION
## Description

This PR addresses the issue of deprecated dynamic property creation in PHP 8.3, as reported in issue [#9](https://github.com/thedevdojo/themes/issues/9). The fix involves explicitly declaring the `$themes_folder` property in the `ThemesServiceProvider` class to comply with PHP 8.3's stricter property handling.

## Changes

- Added a private `$themes_folder` property declaration in `ThemesServiceProvider`.
- Updated the `boot` method to use the newly declared property.

## Impact

This change ensures that `thedevdojo/themes` is compatible with PHP 8.3 and prevents the "Deprecated: Creation of dynamic property" error from being triggered.

## Testing

The changes have been tested in a local environment running PHP 8.3 to ensure that the deprecation warning is resolved and that the functionality of the `ThemesServiceProvider` remains unaffected.

## References

- Issue: [#9](https://github.com/thedevdojo/themes/issues/9) regarding deprecated dynamic property creation in PHP 8.3.

I look forward to any feedback or suggestions regarding this pull request. Thank you for considering this contribution!
